### PR TITLE
Add deep research demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ langgraph-agent-project/
 │   │   └── tools.py             # 工具定义
 │   └── main.py                  # 主应用入口
 ├── examples/
-│   └── basic_usage.py           # 使用示例
+│   ├── basic_usage.py           # 基本使用示例
+│   └── deep_research_demo.py    # 深度研究示例
 ├── tests/
 │   └── test_agent.py            # 测试文件
 ├── docs/                        # 文档目录
@@ -173,6 +174,15 @@ math_config = Configuration(
 
 result = run_agent("请计算圆周率乘以半径为5的圆的面积", math_config)
 print(result)
+```
+
+### 深度研究示例
+
+项目还提供了一个更复杂的研究脚本 `examples/deep_research_demo.py`，
+展示了如何在同一会话中连续提出问题并利用搜索与计算工具。
+
+```bash
+python examples/deep_research_demo.py
 ```
 
 ### Web API使用

--- a/examples/deep_research_demo.py
+++ b/examples/deep_research_demo.py
@@ -1,0 +1,49 @@
+"""深度研究示例
+
+该脚本演示如何使用 LangGraph 代理进行较为复杂的研究会话。
+脚本会在同一线程中连续提出多个问题，展示记忆和多工具组合的效果。
+"""
+
+import os
+import sys
+from dotenv import load_dotenv
+
+# 将 src 目录加入路径，便于直接导入包
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from agent import Configuration, run_agent
+
+# 加载环境变量（如 OPENAI_API_KEY）
+load_dotenv()
+
+
+def deep_research_demo():
+    """运行深度研究示例"""
+    print("=== 深度研究 Demo ===")
+
+    # 自定义配置：启用搜索与计算器工具，开启记忆
+    config = Configuration(
+        enable_weather_tool=False,
+        enable_search_tool=True,
+        enable_calculator_tool=True,
+        system_prompt=(
+            "你是一位学术研究助手，善于搜索资料并汇总关键信息，"
+            "在必要时还能进行数学计算帮助分析。"
+        ),
+    )
+
+    thread_id = "deep_research_session"
+    queries = [
+        "请简要介绍人工智能的发展历史。",
+        "列出人工智能领域的三个重要里程碑。",
+        "计算一下 2024 减去 1956 等于多少。",
+    ]
+
+    for query in queries:
+        print(f"\n用户: {query}")
+        answer = run_agent(query, config, thread_id)
+        print(f"代理: {answer}")
+
+
+if __name__ == "__main__":
+    deep_research_demo()


### PR DESCRIPTION
## Summary
- add a new `deep_research_demo.py` showing a multi-step research session
- document the new example in the project structure and usage section of the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_b_685035363a00832ea0081a732ba78df4