### PR TITLE
Add multi-agent manager example and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ models/
 data/
 *.csv
 *.json
+!electron-app/package.json
 *.parquet
 
 # Docker
@@ -231,3 +232,6 @@ data/
 .DS_Store?
 ehthumbs.db
 Thumbs.db
+# Node
+node_modules/
+electron-app/node_modules/

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ langgraph-agent-project/
 │   └── main.py                  # 主应用入口
 ├── examples/
 │   ├── basic_usage.py           # 基本使用示例
-│   └── deep_research_demo.py    # 深度研究示例
+│   ├── deep_research_demo.py    # 深度研究示例
+│   └── multiagent_demo.py       # 多代理示例
 ├── tests/
 │   └── test_agent.py            # 测试文件
+├── electron-app/               # Electron桌面客户端
 ├── docs/                        # 文档目录
 ├── requirements.txt             # Python依赖
 ├── pyproject.toml              # 项目配置
@@ -183,6 +185,24 @@ print(result)
 
 ```bash
 python examples/deep_research_demo.py
+```
+
+### Multi-Agent Demo
+
+项目还提供了 `examples/multiagent_demo.py`，演示两个代理之间如何通过管理器互相对话。
+
+```bash
+python examples/multiagent_demo.py
+```
+
+### Electron可视化界面
+
+项目提供了 `electron-app` 目录，使用Electron构建桌面界面，可输入提示词并生成相关思考卡片。
+
+```bash
+cd electron-app
+npm install
+npm start
 ```
 
 ### Web API使用

--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>LangGraph Desktop</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="app">
+    <h1>LangGraph Idea Generator</h1>
+    <div class="input-area">
+      <input id="prompt-input" type="text" placeholder="输入你的问题..." />
+      <button id="generate-btn">生成</button>
+    </div>
+    <div id="cards"></div>
+  </div>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,0 +1,54 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const { OpenAI } = require('openai');
+require('dotenv').config();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function generateIdeas(prompt) {
+  const sys = '你是一个头脑风暴助手，针对用户的问题提供3到5个发散性的思考点，每个思考点一句话，以JSON数组返回。';
+  const res = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: sys },
+      { role: 'user', content: prompt }
+    ]
+  });
+  const text = res.choices[0].message.content.trim();
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    return text.split(/\n+/).map(l => l.replace(/^[\-\*\d\.\s]+/, '')).filter(Boolean);
+  }
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 900,
+    height: 700,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+ipcMain.handle('generate-ideas', async (_e, prompt) => {
+  try {
+    const ideas = await generateIdeas(prompt);
+    return ideas.slice(0, 5);
+  } catch (err) {
+    return { error: String(err) };
+  }
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) createWindow();
+});

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "langgraph-desktop",
+  "version": "0.1.0",
+  "description": "Electron UI for LangGraph agent",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^30.0.0",
+    "openai": "^4.0.0",
+    "dotenv": "^16.0.0"
+  }
+}

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  generateIdeas: (prompt) => ipcRenderer.invoke('generate-ideas', prompt)
+});

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -1,0 +1,25 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('prompt-input');
+  const btn = document.getElementById('generate-btn');
+  const cards = document.getElementById('cards');
+
+  async function handle() {
+    const prompt = input.value.trim();
+    if (!prompt) return;
+    cards.innerHTML = '生成中...';
+    const ideas = await window.electronAPI.generateIdeas(prompt);
+    if (!ideas || ideas.error) {
+      cards.innerHTML = `<p class="error">${ideas.error || '生成失败'}</p>`;
+      return;
+    }
+    cards.innerHTML = '';
+    ideas.forEach((idea) => {
+      const div = document.createElement('div');
+      div.className = 'card';
+      div.textContent = idea;
+      cards.appendChild(div);
+    });
+  }
+
+  btn.addEventListener('click', handle);
+});

--- a/electron-app/styles.css
+++ b/electron-app/styles.css
@@ -1,0 +1,40 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+
+.input-area {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+#prompt-input {
+  flex: 1;
+  padding: 8px;
+  font-size: 16px;
+}
+
+#generate-btn {
+  padding: 8px 12px;
+  font-size: 16px;
+}
+
+#cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.card {
+  background: #fafafa;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 12px;
+  width: 30%;
+  min-width: 180px;
+}
+
+.error {
+  color: red;
+}

--- a/examples/multiagent_demo.py
+++ b/examples/multiagent_demo.py
@@ -1,0 +1,49 @@
+"""多代理交互示例
+
+该脚本演示如何使用 ``MultiAgentManager`` 让两个代理互相交流。
+"""
+
+import os
+import sys
+from dotenv import load_dotenv
+
+# 将 src 目录加入路径
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from agent import Configuration
+from multiagent import MultiAgentManager
+
+# 加载环境变量
+load_dotenv()
+
+
+def multiagent_demo():
+    """运行两个代理相互对话的示例"""
+    researcher_config = Configuration(
+        enable_search_tool=True,
+        enable_weather_tool=False,
+        enable_calculator_tool=False,
+        system_prompt="你是一名研究员，擅长查找资料并给出详细解答。",
+    )
+
+    critic_config = Configuration(
+        enable_search_tool=False,
+        enable_weather_tool=False,
+        enable_calculator_tool=False,
+        system_prompt="你是一名评论者，负责对研究员的回答提出批评和改进建议。",
+    )
+
+    manager = MultiAgentManager({"researcher": researcher_config, "critic": critic_config})
+
+    question = "请简要介绍人工智能的前景。"
+    print(f"用户: {question}")
+
+    researcher_reply = manager.send_to_agent("researcher", question)
+    print(f"研究员: {researcher_reply}")
+
+    critic_reply = manager.relay_message("researcher", "critic", researcher_reply)
+    print(f"评论员: {critic_reply}")
+
+
+if __name__ == "__main__":
+    multiagent_demo()

--- a/src/multiagent/__init__.py
+++ b/src/multiagent/__init__.py
@@ -1,0 +1,5 @@
+"""Multi-agent management package"""
+
+from .manager import MultiAgentManager
+
+__all__ = ["MultiAgentManager"]

--- a/src/multiagent/manager.py
+++ b/src/multiagent/manager.py
@@ -1,0 +1,46 @@
+"""Multi-agent manager module.
+
+This module provides a ``MultiAgentManager`` class that can
+instantiate multiple agent graphs and route messages between them.
+"""
+
+from typing import Dict, List
+
+from langchain_core.messages import AIMessage, HumanMessage, BaseMessage
+
+from agent import Configuration, create_agent_graph
+
+
+class MultiAgentManager:
+    """Manager for coordinating multiple agents."""
+
+    def __init__(self, configs: Dict[str, Configuration]):
+        """Create manager with a mapping of agent name to ``Configuration``."""
+        self.graphs = {name: create_agent_graph(cfg) for name, cfg in configs.items()}
+        self.histories: Dict[str, List[BaseMessage]] = {name: [] for name in configs}
+
+    def send_to_agent(self, agent_name: str, message: str) -> str:
+        """Send a message to a specific agent and get its reply."""
+        history = self.histories[agent_name]
+        state = {
+            "messages": history + [HumanMessage(content=message)],
+            "iteration_count": 0,
+            "user_input": message,
+            "final_answer": None,
+        }
+        result = self.graphs[agent_name].invoke(state)
+        history.append(HumanMessage(content=message))
+        history.extend(result["messages"])
+        reply = ""
+        for msg in reversed(result["messages"]):
+            if isinstance(msg, AIMessage):
+                reply = msg.content
+                break
+        return reply
+
+    def relay_message(self, sender: str, receiver: str, message: str) -> str:
+        """Relay a message from one agent to another."""
+        reply = self.send_to_agent(receiver, message)
+        # Receiver's reply becomes the next input for the sender
+        self.histories[sender].append(HumanMessage(content=reply))
+        return reply

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -1,0 +1,46 @@
+"""多代理管理器测试"""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# 添加src目录到Python路径
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from agent import Configuration
+from multiagent import MultiAgentManager
+
+
+@patch('agent.graph.ChatOpenAI')
+def test_relay_between_agents(mock_openai):
+    """测试代理之间消息转发"""
+
+    def make_llm(reply: str):
+        mock_llm = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = reply
+        mock_resp.tool_calls = []
+        mock_llm.bind_tools.return_value.invoke.return_value = mock_resp
+        return mock_llm
+
+    mock_openai.side_effect = [make_llm("A1"), make_llm("B1")]
+
+    configs = {
+        "researcher": Configuration(enable_weather_tool=False, enable_search_tool=False, enable_calculator_tool=False),
+        "critic": Configuration(enable_weather_tool=False, enable_search_tool=False, enable_calculator_tool=False),
+    }
+
+    manager = MultiAgentManager(configs)
+
+    # 发送消息给researcher
+    reply_a = manager.send_to_agent("researcher", "hello")
+    assert reply_a == "A1"
+    # researcher 回复 critic
+    reply_b = manager.relay_message("researcher", "critic", reply_a)
+    assert reply_b == "B1"
+
+    # 检查历史记录
+    assert any(msg.content == "A1" for msg in manager.histories["researcher"] if hasattr(msg, "content"))
+    assert any(msg.content == "B1" for msg in manager.histories["critic"] if hasattr(msg, "content"))


### PR DESCRIPTION
## Summary
- create `MultiAgentManager` for coordinating multiple agents
- add demo script showing researcher and critic interaction
- document the new example and update project tree in README
- introduce tests for the multi-agent manager
- add Electron desktop client for idea generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_b_6850b10e6808832e8ccf08ec7f082710